### PR TITLE
Conserto em config de query do mongodb

### DIFF
--- a/config/mongodb.js
+++ b/config/mongodb.js
@@ -2,16 +2,16 @@ const envLoader = require('@b2wads/env-o-loader')
 
 const configSpec = {
   defaults: {
-    query: '{}',
-    queryOptions: '{}',
+    query: {},
+    queryOptions: {},
     uri: 'mongodb://localhost',
   },
 
   test: {
     collection: 'test_collection',
     database: 'test_database',
-    query: '{"find":true}',
-    queryOptions: '{"sort":{"name":-1}}',
+    query: { find: true },
+    queryOptions: { sort: { name: -1 } },
     uri: 'env:TEST_B2WADS_MONGODB_URI',
   },
 
@@ -24,13 +24,7 @@ const configSpec = {
   },
 }
 
-const rawConfig = envLoader(configSpec)
-
-const config = {
-  ...rawConfig,
-  query: JSON.parse(rawConfig.query),
-  queryOptions: JSON.parse(rawConfig.queryOptions),
-}
+const config = envLoader(configSpec)
 
 const validateConfig = (conf) => {
   if (!conf.collection) throw Error('invalid mongodb configuration: missing "collection"')


### PR DESCRIPTION
A lib `@b2wads/env-o-loader` possui alguma inconsistência no carregamento de configurações que não consegui identificar. Ao utilizar uma string literal representando um JSON diretamente nas configurações, a lib preserva o valor como string mas ao passar a mesma string via envvar a lib converte-a para objeto.

Na v1, tive que fazer parse manual da string mas ao subir o código para produção e passar a config via env, a lib converteu a string e o parse manual quebrou.